### PR TITLE
Feature [#18] Create Work Migration

### DIFF
--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Employee extends Model
 {
@@ -14,4 +15,11 @@ class Employee extends Model
     protected $fillable = [
         'name',
     ];
+
+    public function works(): BelongsToMany
+    {
+        return $this->belongsToMany(Pharmacy::class, 'works', 'employee_id', 'pharmacy_id')
+            ->withPivot('shift_start', 'shift_end')
+            ->withTimestamps();
+    }
 }

--- a/app/Models/Pharmacy.php
+++ b/app/Models/Pharmacy.php
@@ -24,4 +24,11 @@ class Pharmacy extends Model
             ->withPivot('start_date', 'end_date')
             ->withTimestamps();
     }
+
+    public function employees(): BelongsToMany
+    {
+        return $this->belongsToMany(Employee::class, 'works', 'phar_id', 'employee_id')
+            ->withPivot('shift_start', 'shift_end')
+            ->withTimestamps();
+    }
 }

--- a/database/migrations/2024_09_17_111441_create_works_table.php
+++ b/database/migrations/2024_09_17_111441_create_works_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('works', function (Blueprint $table) {
+            $table->unsignedBigInteger('employee_id');
+            $table->unsignedInteger('pharmacy_id');
+            $table->datetime('shift_start');
+            $table->datetime('shift_end');
+            $table->timestamps();
+
+            $table->foreign('employee_id')
+                ->references('employee_id')
+                ->on('employees')
+                ->onDelete('cascade');
+
+            $table->foreign('pharmacy_id')
+                ->references('phar_id')
+                ->on('pharmacies')
+                ->onDelete('cascade');
+
+            $table->primary(['employee_id', 'shift_start', 'shift_end']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('works');
+    }
+};


### PR DESCRIPTION
Fixes #18 

- Create `works` table serving as the pivot table between `employees` and `pharmacies` table. 
- Add `works()` method in employee and `employees()` method in pharmacy models.